### PR TITLE
Parse uppercase squares

### DIFF
--- a/src/ptn.rs
+++ b/src/ptn.rs
@@ -499,6 +499,20 @@ mod tests {
     }
 
     #[test]
+    fn square_capitalization() {
+        transform::<Square, _, _>([
+            ("A3", "a3"),
+            ("B1", "b1"),
+            ("C4", "c4"),
+            ("D1", "d1"),
+            ("E5", "e5"),
+            ("F8", "f8"),
+            ("G7", "g7"),
+            ("H6", "h6"),
+        ])
+    }
+
+    #[test]
     fn invalid_moves() {
         use ParseMoveError::*;
 

--- a/src/ptn.rs
+++ b/src/ptn.rs
@@ -64,7 +64,7 @@ impl FromStr for Square {
         if let Some(column_char) = chars.next() {
             if let Some(row_char) = chars.next() {
                 if chars.next() == None {
-                    let column = (column_char as u32).wrapping_sub('a' as u32);
+                    let column = (column_char.to_ascii_lowercase() as u32).wrapping_sub('a' as u32);
                     let row = (row_char as u32).wrapping_sub('1' as u32);
                     return if column >= 8 {
                         Err(BadColumn)


### PR DESCRIPTION
Motivation for this change is that PlayTak sends squares with capital letters for columns.