### PR TITLE
Fix off-by-one error in ply

### DIFF
--- a/src/tps.rs
+++ b/src/tps.rs
@@ -267,7 +267,7 @@ impl Tps {
     }
 
     pub fn ply(&self) -> usize {
-        self.full_move() * 2
+        (self.full_move() - 1) * 2
             + if let Color::White = self.color() {
                 0
             } else {


### PR DESCRIPTION
Currently the plies start with 2, since full moves begin with 1. I believe you intended the plies to start at 0, so this change fixes it.