### PR TITLE
Appease clippy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ impl FromStr for Piece {
 
         let c = chars.next();
 
-        if chars.next() != None {
+        if chars.next().is_some() {
             Err(TooLong)?
         }
 

--- a/src/tps.rs
+++ b/src/tps.rs
@@ -267,12 +267,7 @@ impl Tps {
     }
 
     pub fn ply(&self) -> usize {
-        (self.full_move() - 1) * 2
-            + if let Color::White = self.color() {
-                0
-            } else {
-                1
-            }
+        (self.full_move() - 1) * 2 + usize::from(Color::White != self.color())
     }
 
     pub fn starting_position(size: usize) -> Self {


### PR DESCRIPTION
Appease clippy by applying all suggestions. Mainly consists of using `Option::is_none` and `Option::is_some` instead of `== None` and `!= None` respectively.