### PR TITLE
Add full documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![warn(missing_docs)]
+//! `takparse` is a library which provides helpful types and functions
+//! for parsing objects related to the abstract strategy board game Tak.
+
 #[cfg(test)]
 mod test_utils;
 
@@ -13,14 +17,18 @@ use std::{
     str::FromStr,
 };
 
-// TODO: serde, docs, tests
+// TODO: serde, tests
 
 // TODO: full ptn strings
 
+/// Enum representing the piece type.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Piece {
+    /// Flat stone
     Flat,
+    /// Wall, also known as standing stone
     Wall,
+    /// Capstone
     Cap,
 }
 
@@ -41,9 +49,12 @@ impl Display for Piece {
     }
 }
 
+/// Error returned when something goes wrong during the parsing of a [`Piece`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ParsePieceError {
+    /// Pieces should only be single characters. This variant is returned when a piece is not a single character.
     TooLong,
+    /// Pieces should be one of 'F', 'S', and 'C'. If they are not, this variant is returned.
     BadChar,
 }
 

--- a/src/ptn.rs
+++ b/src/ptn.rs
@@ -52,16 +52,18 @@ impl Square {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::{Direction, Square};
-    /// let square: Square = "c3".parse().unwrap();
+    /// # use takparse::{Direction, Square, ParseSquareError};
+    /// let square: Square = "c3".parse()?;
     /// assert_eq!(square.shift(Direction::Up, 1).to_string(), "c4");
     /// assert_eq!(square.shift(Direction::Left, 2).to_string(), "a3");
+    /// # Ok::<(), ParseSquareError>(())
     /// ```
     ///
     /// ```should_panic
-    /// # use takparse::{Direction, Square};
-    /// let square: Square = "c3".parse().unwrap();
+    /// # use takparse::{Direction, Square, ParseSquareError};
+    /// let square: Square = "c3".parse()?;
     /// assert_eq!(square.shift(Direction::Down, 3).to_string(), "c0"); // fails
+    /// # Ok::<(), ParseSquareError>(())
     /// ```
     pub fn shift(self, direction: Direction, amount: i8) -> Self {
         let Self { column, row } = self;
@@ -103,13 +105,14 @@ impl Square {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::{Direction, Square};
-    /// let square: Square = "e3".parse().unwrap();
+    /// # use takparse::{Direction, Square, ParseSquareError};
+    /// let square: Square = "e3".parse()?;
     /// assert_eq!(
     ///     square.checked_step(Direction::Up, 5),
-    ///     Some("e4".parse().unwrap())
+    ///     Some("e4".parse()?)
     /// );
     /// assert_eq!(square.checked_step(Direction::Right, 5), None);
+    /// # Ok::<(), ParseSquareError>(())
     /// ```
     pub fn checked_step(self, direction: Direction, board_size: u8) -> Option<Self> {
         self.assert_on_board(board_size);
@@ -133,12 +136,13 @@ impl Square {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::Square;
-    /// let square: Square = "b2".parse().unwrap();
+    /// # use takparse::{Square, ParseSquareError};
+    /// let square: Square = "b2".parse()?;
     /// assert_eq!(square.rotate(6).to_string(), "b5");
     /// assert_eq!(square.rotate(6).rotate(6).to_string(), "e5");
     /// assert_eq!(square.rotate(6).rotate(6).rotate(6).to_string(), "e2");
     /// assert_eq!(square.rotate(6).rotate(6).rotate(6).rotate(6), square);
+    /// # Ok::<(), ParseSquareError>(())
     /// ```
     #[must_use]
     pub const fn rotate(self, board_size: u8) -> Self {
@@ -158,10 +162,11 @@ impl Square {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::Square;
-    /// let square: Square = "b2".parse().unwrap();
+    /// # use takparse::{Square, ParseSquareError};
+    /// let square: Square = "b2".parse()?;
     /// assert_eq!(square.mirror(6).to_string(), "b5");
     /// assert_eq!(square.mirror(5).to_string(), "b4");
+    /// # Ok::<(), ParseSquareError>(())
     /// ```
     #[must_use]
     pub const fn mirror(self, board_size: u8) -> Self {
@@ -389,12 +394,13 @@ impl FromStr for Direction {
 /// # Examples
 ///
 /// ```
-/// # use takparse::{Move, MoveKind};
-/// let spread: Move = "6a1+123".parse().unwrap();
+/// # use takparse::{Move, MoveKind, ParseMoveError};
+/// let spread: Move = "6a1+123".parse()?;
 /// if let MoveKind::Spread(_direction, pattern) = spread.kind() {
 ///     let counts: Vec<u32> = pattern.drop_counts().into_iter().collect();
 ///     assert_eq!(counts, vec![1, 2, 3]);
 /// }
+/// # Ok::<(), ParseMoveError>(())
 /// ```
 ///
 /// ```
@@ -458,19 +464,21 @@ impl Iterator for DropCounts {
 /// # Examples
 ///
 /// ```
-/// # use takparse::{Move, MoveKind};
-/// let spread: Move = "6a1+123".parse().unwrap();
+/// # use takparse::{Move, MoveKind, ParseMoveError};
+/// let spread: Move = "6a1+123".parse()?;
 /// if let MoveKind::Spread(_direction, pattern) = spread.kind() {
 ///     assert_eq!(pattern.mask(), 0b0010_1100);
 /// }
+/// # Ok::<(), ParseMoveError>(())
 /// ```
 ///
 /// ```
-/// # use takparse::{Move, MoveKind};
-/// let spread: Move = "4a1+121".parse().unwrap();
+/// # use takparse::{Move, MoveKind, ParseMoveError};
+/// let spread: Move = "4a1+121".parse()?;
 /// if let MoveKind::Spread(_direction, pattern) = spread.kind() {
 ///     assert_eq!(pattern.mask(), 0b1011_0000);
 /// }
+/// # Ok::<(), ParseMoveError>(())
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Pattern(u8);
@@ -485,11 +493,12 @@ impl Pattern {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::{Move, MoveKind, Pattern};
-    /// let spread: Move = "3a1>21".parse().unwrap();
+    /// # use takparse::{Move, MoveKind, Pattern, ParseMoveError};
+    /// let spread: Move = "3a1>21".parse()?;
     /// if let MoveKind::Spread(_direction, pattern) = spread.kind() {
     ///     assert_eq!(Pattern::from_mask(0b1010_0000), pattern);
     /// }
+    /// # Ok::<(), ParseMoveError>(())
     /// ```
     pub fn from_mask(mask: u8) -> Self {
         assert!(mask != 0x00 && mask != 0xFF);
@@ -522,11 +531,12 @@ impl Pattern {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::{Move, MoveKind};
-    /// let spread: Move = "3a1>21".parse().unwrap();
+    /// # use takparse::{Move, MoveKind, ParseMoveError};
+    /// let spread: Move = "3a1>21".parse()?;
     /// if let MoveKind::Spread(_direction, pattern) = spread.kind() {
     ///     assert_eq!(pattern.count_pieces(), 3);
     /// }
+    /// # Ok::<(), ParseMoveError>(())
     /// ```
     pub fn count_pieces(self) -> u32 {
         u8::BITS - self.0.trailing_zeros()
@@ -539,11 +549,12 @@ impl Pattern {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::{Move, MoveKind};
-    /// let spread: Move = "3a1>21".parse().unwrap();
+    /// # use takparse::{Move, MoveKind, ParseMoveError};
+    /// let spread: Move = "3a1>21".parse()?;
     /// if let MoveKind::Spread(_direction, pattern) = spread.kind() {
     ///     assert_eq!(pattern.count_squares(), 2);
     /// }
+    /// # Ok::<(), ParseMoveError>(())
     /// ```
     pub fn count_squares(self) -> u32 {
         self.0.count_ones()
@@ -555,11 +566,12 @@ impl Pattern {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::{Move, MoveKind};
-    /// let spread: Move = "3a1>21".parse().unwrap();
+    /// # use takparse::{Move, MoveKind, ParseMoveError};
+    /// let spread: Move = "3a1>21".parse()?;
     /// if let MoveKind::Spread(_direction, pattern) = spread.kind() {
     ///     assert_eq!(pattern.count_final_square_pieces(), 1);
     /// }
+    /// # Ok::<(), ParseMoveError>(())
     /// ```
     pub fn count_final_square_pieces(self) -> u32 {
         self.0.leading_zeros() + 1
@@ -687,18 +699,19 @@ impl Move {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::{Move, MoveKind, Square, Pattern, Direction};
+    /// # use takparse::{Move, MoveKind, Square, Pattern, Direction, ParseMoveError};
     /// // Constructing the move from parts.
-    /// let square: Square = "c2".parse().unwrap();
-    /// let pattern: Pattern = "123".parse().unwrap();
+    /// let square: Square = "c2".parse()?;
+    /// let pattern: Pattern = "123".parse()?;
     /// let kind: MoveKind = MoveKind::Spread(Direction::Up, pattern);
     /// let my_move = Move::new(square, kind);
     ///
     /// // Parsing a move.
-    /// let parsed_move: Move = "6c2+123".parse().unwrap();
+    /// let parsed_move: Move = "6c2+123".parse()?;
     ///
     /// // We get the same thing at the end.
     /// assert_eq!(my_move, parsed_move);
+    /// # Ok::<(), ParseMoveError>(())
     /// ```
     pub fn new(square: Square, kind: MoveKind) -> Self {
         Self { square, kind }

--- a/src/ptn.rs
+++ b/src/ptn.rs
@@ -25,12 +25,14 @@ impl Square {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::Square;
     /// assert_eq!(Square::new(0, 0).to_string(), "a1");
     /// assert_eq!(Square::new(1, 0).to_string(), "b1");
     /// assert_eq!(Square::new(0, 1).to_string(), "a2");
     /// ```
     ///
     /// ```should_panic
+    /// # use takparse::Square;
     /// assert_eq!(Square::new(25, 8).to_string(), "z9"); // fails
     /// ```
     pub fn new(column: u8, row: u8) -> Self {
@@ -50,12 +52,14 @@ impl Square {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::{Direction, Square};
     /// let square: Square = "c3".parse().unwrap();
     /// assert_eq!(square.shift(Direction::Up, 1).to_string(), "c4");
     /// assert_eq!(square.shift(Direction::Left, 2).to_string(), "a3");
     /// ```
     ///
     /// ```should_panic
+    /// # use takparse::{Direction, Square};
     /// let square: Square = "c3".parse().unwrap();
     /// assert_eq!(square.shift(Direction::Down, 3).to_string(), "c0"); // fails
     /// ```
@@ -99,6 +103,7 @@ impl Square {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::{Direction, Square};
     /// let square: Square = "e3".parse().unwrap();
     /// assert_eq!(
     ///     square.checked_step(Direction::Up, 5),
@@ -128,6 +133,7 @@ impl Square {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::Square;
     /// let square: Square = "b2".parse().unwrap();
     /// assert_eq!(square.rotate(6).to_string(), "b5");
     /// assert_eq!(square.rotate(6).rotate(6).to_string(), "e5");
@@ -152,6 +158,7 @@ impl Square {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::Square;
     /// let square: Square = "b2".parse().unwrap();
     /// assert_eq!(square.mirror(6).to_string(), "b5");
     /// assert_eq!(square.mirror(5).to_string(), "b4");
@@ -257,6 +264,7 @@ impl Direction {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::Direction;
     /// assert_eq!(Direction::Up.offset(), (0, 1));
     /// assert_eq!(Direction::Left.offset(), (-1, 0));
     /// ```
@@ -274,6 +282,7 @@ impl Direction {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::Direction;
     /// assert_eq!(Direction::Up.rotate(), Direction::Right);
     /// assert_eq!(Direction::Left.rotate(), Direction::Up);
     /// ```
@@ -293,6 +302,7 @@ impl Direction {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::Direction;
     /// assert_eq!(Direction::Up.mirror(), Direction::Down);
     /// assert_eq!(Direction::Left.mirror(), Direction::Left);
     /// ```
@@ -379,6 +389,7 @@ impl FromStr for Direction {
 /// # Examples
 ///
 /// ```
+/// # use takparse::{Move, MoveKind};
 /// let spread: Move = "6a1+123".parse().unwrap();
 /// if let MoveKind::Spread(_direction, pattern) = spread.kind() {
 ///     let counts: Vec<u32> = pattern.drop_counts().into_iter().collect();
@@ -387,9 +398,11 @@ impl FromStr for Direction {
 /// ```
 ///
 /// ```
-/// # let pattern = Pattern::from_mask(0b0010_1100);
+/// # use takparse::Pattern;
+/// let pattern = Pattern::from_mask(0b0010_1100);
 /// // for loops can omit `.into_iter()`
 /// for count in pattern.drop_counts() {
+///     // prints 1 2 3
 ///     println!("{count}");
 /// }
 /// ```
@@ -445,6 +458,7 @@ impl Iterator for DropCounts {
 /// # Examples
 ///
 /// ```
+/// # use takparse::{Move, MoveKind};
 /// let spread: Move = "6a1+123".parse().unwrap();
 /// if let MoveKind::Spread(_direction, pattern) = spread.kind() {
 ///     assert_eq!(pattern.mask(), 0b0010_1100);
@@ -452,6 +466,7 @@ impl Iterator for DropCounts {
 /// ```
 ///
 /// ```
+/// # use takparse::{Move, MoveKind};
 /// let spread: Move = "4a1+121".parse().unwrap();
 /// if let MoveKind::Spread(_direction, pattern) = spread.kind() {
 ///     assert_eq!(pattern.mask(), 0b1011_0000);
@@ -470,6 +485,7 @@ impl Pattern {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::{Move, MoveKind, Pattern};
     /// let spread: Move = "3a1>21".parse().unwrap();
     /// if let MoveKind::Spread(_direction, pattern) = spread.kind() {
     ///     assert_eq!(Pattern::from_mask(0b1010_0000), pattern);
@@ -491,8 +507,10 @@ impl Pattern {
     ///
     /// # Examples
     /// ```
-    /// # pattern = Pattern::from_mask(0x0111_0000);
+    /// # use takparse::Pattern;
+    /// let pattern = Pattern::from_mask(0b0111_0000);
     /// for count in pattern.drop_counts() {
+    ///     // prints 1, 1, 2
     ///     println!("{count}");
     /// }
     pub fn drop_counts(self) -> DropCounts {
@@ -504,6 +522,7 @@ impl Pattern {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::{Move, MoveKind};
     /// let spread: Move = "3a1>21".parse().unwrap();
     /// if let MoveKind::Spread(_direction, pattern) = spread.kind() {
     ///     assert_eq!(pattern.count_pieces(), 3);
@@ -520,6 +539,7 @@ impl Pattern {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::{Move, MoveKind};
     /// let spread: Move = "3a1>21".parse().unwrap();
     /// if let MoveKind::Spread(_direction, pattern) = spread.kind() {
     ///     assert_eq!(pattern.count_squares(), 2);
@@ -535,6 +555,7 @@ impl Pattern {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::{Move, MoveKind};
     /// let spread: Move = "3a1>21".parse().unwrap();
     /// if let MoveKind::Spread(_direction, pattern) = spread.kind() {
     ///     assert_eq!(pattern.count_final_square_pieces(), 1);
@@ -666,6 +687,7 @@ impl Move {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::{Move, MoveKind, Square, Pattern, Direction};
     /// // Constructing the move from parts.
     /// let square: Square = "c2".parse().unwrap();
     /// let pattern: Pattern = "123".parse().unwrap();

--- a/src/tps.rs
+++ b/src/tps.rs
@@ -76,6 +76,7 @@ impl Stack {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::{Stack, Color, Piece};
     /// // In TPS this is a stack of a black capstone on top of a white flat.
     /// let stack: Stack = "12C".parse().unwrap();
     ///
@@ -84,6 +85,7 @@ impl Stack {
     /// ```
     ///
     /// ```should_panic
+    /// # use takparse::{Stack, Piece};
     /// Stack::new(Piece::Flat, [].into_iter()); // panics
     /// ```
     pub fn new<I: IntoIterator<Item = Color>>(top: Piece, colors: I) -> Self {
@@ -104,6 +106,7 @@ impl Stack {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::{Stack, Color};
     /// let stack: Stack = "122C".parse().unwrap();
     /// let colors: Vec<Color> = stack.colors().collect();
     /// assert_eq!(colors, vec![Color::White, Color::Black, Color::Black]);
@@ -290,11 +293,13 @@ impl Tps {
     ///
     /// This function is perfectly safe at the moment.
     /// The reason for the `unsafe` is to reserve the possibility of having undefined behavior
-    /// when an invalid board state is passed in as input.
+    /// in the future when an invalid board state is passed in as input.
     ///
     /// # Examples
     ///
     /// ```
+    /// # use takparse::{Tps, Stack, ExtendedSquare, Color};
+    /// # use std::num::NonZeroUsize;
     /// let stack: Stack = "112C".parse().unwrap();
     /// let board = vec![
     ///     vec![
@@ -366,6 +371,7 @@ impl Tps {
     /// # Examples
     ///
     /// ```
+    /// # use takparse::Tps;
     /// let tps: Tps = "x3/x3/x3 1 23".parse().unwrap();
     /// assert_eq!(tps.ply(), 44);
     /// ```

--- a/src/tps.rs
+++ b/src/tps.rs
@@ -76,12 +76,13 @@ impl Stack {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::{Stack, Color, Piece};
+    /// # use takparse::{Stack, Color, Piece, ParseTpsError};
     /// // In TPS this is a stack of a black capstone on top of a white flat.
-    /// let stack: Stack = "12C".parse().unwrap();
+    /// let stack: Stack = "12C".parse()?;
     ///
     /// let colors = vec![Color::White, Color::Black];
     /// assert_eq!(Stack::new(Piece::Cap, colors.into_iter()), stack);
+    /// # Ok::<(), ParseTpsError>(())
     /// ```
     ///
     /// ```should_panic
@@ -106,10 +107,11 @@ impl Stack {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::{Stack, Color};
-    /// let stack: Stack = "122C".parse().unwrap();
+    /// # use takparse::{Stack, Color, ParseTpsError};
+    /// let stack: Stack = "122C".parse()?;
     /// let colors: Vec<Color> = stack.colors().collect();
     /// assert_eq!(colors, vec![Color::White, Color::Black, Color::Black]);
+    /// # Ok::<(), ParseTpsError>(())
     /// ```
     pub fn colors(&self) -> impl Iterator<Item = Color> + '_ {
         self.colors.iter().copied()
@@ -298,9 +300,9 @@ impl Tps {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::{Tps, Stack, ExtendedSquare, Color};
+    /// # use takparse::{Tps, Stack, ExtendedSquare, Color, ParseTpsError};
     /// # use std::num::NonZeroUsize;
-    /// let stack: Stack = "112C".parse().unwrap();
+    /// let stack: Stack = "112C".parse()?;
     /// let board = vec![
     ///     vec![
     ///         ExtendedSquare::Stack(stack),
@@ -311,7 +313,8 @@ impl Tps {
     /// ];
     /// let tps =
     ///     unsafe { Tps::new_unchecked(board, Color::Black, NonZeroUsize::new_unchecked(10)) };
-    /// assert_eq!(tps, "112C,x2/x3/x3 2 10".parse().unwrap());
+    /// assert_eq!(tps, "112C,x2/x3/x3 2 10".parse()?);
+    /// # Ok::<(), ParseTpsError>(())
     /// ```
     pub unsafe fn new_unchecked(
         mut board: Vec<Vec<ExtendedSquare>>,
@@ -334,8 +337,8 @@ impl Tps {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::Tps;
-    /// let tps: Tps = "1,2,12S/2,x2/x2,211C 1 15".parse().unwrap();
+    /// # use takparse::{Tps, ParseTpsError};
+    /// let tps: Tps = "1,2,12S/2,x2/x2,211C 1 15".parse()?;
     /// for row in tps.board_2d() {
     ///     for square in row {
     ///         let out = match square {
@@ -346,6 +349,7 @@ impl Tps {
     ///         println!("{out}");
     ///     }
     /// }
+    /// # Ok::<(), ParseTpsError>(())
     /// ```
     pub fn board_2d(&self) -> impl Iterator<Item = impl Iterator<Item = Option<&'_ Stack>>> {
         self.board
@@ -361,8 +365,8 @@ impl Tps {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::Tps;
-    /// let tps: Tps = "1,2,12S/2,x2/x2,211C 1 15".parse().unwrap();
+    /// # use takparse::{Tps, ParseTpsError};
+    /// let tps: Tps = "1,2,12S/2,x2/x2,211C 1 15".parse()?;
     /// for square in tps.board() {
     ///     let out = match square {
     ///         Some(stack) => "stack",
@@ -371,6 +375,7 @@ impl Tps {
     ///     // prints stack, stack, stack, stack, empty, empty, empty, empty, stack
     ///     println!("{out}");
     /// }
+    /// # Ok::<(), ParseTpsError>(())
     /// ```
     pub fn board(&self) -> impl Iterator<Item = Option<&'_ Stack>> {
         self.board_2d().flatten()
@@ -383,9 +388,10 @@ impl Tps {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::Tps;
-    /// let tps: Tps = "1,2,12S/2,x2/x2,211C 1 15".parse().unwrap();
+    /// # use takparse::{Tps, ParseTpsError};
+    /// let tps: Tps = "1,2,12S/2,x2/x2,211C 1 15".parse()?;
     /// assert_eq!(tps.size(), 3);
+    /// # Ok::<(), ParseTpsError>(())
     /// ```
     pub fn size(&self) -> usize {
         self.board.len()
@@ -411,9 +417,10 @@ impl Tps {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::Tps;
-    /// let tps: Tps = "x3/x3/x3 1 23".parse().unwrap();
+    /// # use takparse::{Tps, ParseTpsError};
+    /// let tps: Tps = "x3/x3/x3 1 23".parse()?;
     /// assert_eq!(tps.ply(), 44);
+    /// # Ok::<(), ParseTpsError>(())
     /// ```
     pub fn ply(&self) -> usize {
         (self.full_move() - 1) * 2
@@ -431,8 +438,9 @@ impl Tps {
     /// # Examples
     ///
     /// ```
-    /// # use takparse::Tps;
-    /// assert_eq!(Tps::starting_position(4), "x4/x4/x4/x4 1 1".parse().unwrap())
+    /// # use takparse::{Tps, ParseTpsError};
+    /// assert_eq!(Tps::starting_position(4), "x4/x4/x4/x4 1 1".parse()?);
+    /// # Ok::<(), ParseTpsError>(())
     /// ```
     pub fn starting_position(size: usize) -> Self {
         start_position_tps(size).parse().unwrap()

--- a/src/tps.rs
+++ b/src/tps.rs
@@ -330,6 +330,23 @@ impl Tps {
     /// The outer iterator iterates over rows, the inner iterator iterates over squares.
     /// Each element in the inner iterator is an option, where [`None`] means the square is empty.
     /// The [`Some`] variant has a [`Stack`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use takparse::Tps;
+    /// let tps: Tps = "1,2,12S/2,x2/x2,211C 1 15".parse().unwrap();
+    /// for row in tps.board_2d() {
+    ///     for square in row {
+    ///         let out = match square {
+    ///             Some(stack) => "stack",
+    ///             None => "empty",
+    ///         };
+    ///         // prints stack, stack, stack, stack, empty, empty, empty, empty, stack
+    ///         println!("{out}");
+    ///     }
+    /// }
+    /// ```
     pub fn board_2d(&self) -> impl Iterator<Item = impl Iterator<Item = Option<&'_ Stack>>> {
         self.board
             .iter()
@@ -340,6 +357,21 @@ impl Tps {
     /// variant means the square is empty and the [`Some`] variant houses a [`Stack`].
     ///
     /// This function is just a flattened version of [`Tps::board_2d`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use takparse::Tps;
+    /// let tps: Tps = "1,2,12S/2,x2/x2,211C 1 15".parse().unwrap();
+    /// for square in tps.board() {
+    ///     let out = match square {
+    ///         Some(stack) => "stack",
+    ///         None => "empty",
+    ///     };
+    ///     // prints stack, stack, stack, stack, empty, empty, empty, empty, stack
+    ///     println!("{out}");
+    /// }
+    /// ```
     pub fn board(&self) -> impl Iterator<Item = Option<&'_ Stack>> {
         self.board_2d().flatten()
     }
@@ -347,6 +379,14 @@ impl Tps {
     /// Get the size of the board.
     ///
     /// For board with 6 rows (normal 6x6 board), this returns 6.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use takparse::Tps;
+    /// let tps: Tps = "1,2,12S/2,x2/x2,211C 1 15".parse().unwrap();
+    /// assert_eq!(tps.size(), 3);
+    /// ```
     pub fn size(&self) -> usize {
         self.board.len()
     }
@@ -387,6 +427,13 @@ impl Tps {
     /// Generate the [`Tps`] for a board of the given `size`.
     ///
     /// The starting position is all squares empty, turn 1, white to move.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use takparse::Tps;
+    /// assert_eq!(Tps::starting_position(4), "x4/x4/x4/x4 1 1".parse().unwrap())
+    /// ```
     pub fn starting_position(size: usize) -> Self {
         start_position_tps(size).parse().unwrap()
     }


### PR DESCRIPTION
Documents every single public-facing struct, enum, function.
Documentation includes plenty of examples. Panics and safety are also documented.

The doc-tests also work as new tests.

Deprecated unused variant `ParseTpsError::MissingPiece`.

Closes #4.