### PR TITLE
Add parsing for PTN files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ repository = "https://github.com/alion02/takparse"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = "0.4"

--- a/src/file.rs
+++ b/src/file.rs
@@ -238,6 +238,18 @@ impl Ptn {
 }
 
 impl Ptn {
+    pub fn tags(&self) -> &[Tag] {
+        &self.tags
+    }
+
+    pub fn moves(&self) -> &[Move] {
+        &self.moves
+    }
+
+    pub fn comments(&self) -> &[Vec<String>] {
+        &self.comments
+    }
+
     /// Get the first matching tag's value.
     pub fn get_tag(&self, key: &str) -> Option<&str> {
         for tag in &self.tags {

--- a/src/file.rs
+++ b/src/file.rs
@@ -142,3 +142,71 @@ impl FromStr for Tag {
         Ok(Self::new(key, value))
     }
 }
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum WinReason {
+    Road,
+    Flat,
+    #[default]
+    Other,
+}
+
+impl Display for WinReason {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::Road => "R",
+            Self::Flat => "F",
+            Self::Other => "1",
+        }
+        .fmt(f)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum GameResult {
+    White(WinReason),
+    Black(WinReason),
+    #[default]
+    Draw,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ParseGameResultError {
+    Invalid,
+}
+
+impl Display for ParseGameResultError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "invalid or unknown game result")
+    }
+}
+
+impl Error for ParseGameResultError {}
+
+impl Display for GameResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::White(reason) => write!(f, "{reason}-0"),
+            Self::Black(reason) => write!(f, "0-{reason}"),
+            Self::Draw => write!(f, "1/2-1/2"),
+        }
+    }
+}
+
+impl FromStr for GameResult {
+    type Err = ParseGameResultError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "F-0" => GameResult::White(WinReason::Flat),
+            "R-0" => GameResult::White(WinReason::Road),
+            "1-0" => GameResult::White(WinReason::Other),
+            "0-F" => GameResult::Black(WinReason::Flat),
+            "0-R" => GameResult::Black(WinReason::Road),
+            "0-1" => GameResult::Black(WinReason::Other),
+            "1/2-1/2" => GameResult::Draw,
+            _ => Err(ParseGameResultError::Invalid)?,
+        })
+    }
+}
+

--- a/src/file.rs
+++ b/src/file.rs
@@ -8,6 +8,8 @@ use std::{
     str::FromStr,
 };
 
+// TODO docs
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Tag {
     key: String,
@@ -310,6 +312,10 @@ impl Ptn {
 
     pub fn clock(&self) -> Option<&str> {
         self.get_tag("Clock")
+    }
+
+    pub fn opening(&self) -> Option<&str> {
+        self.get_tag("Opening")
     }
 
     pub fn result(&self) -> Option<GameResult> {
@@ -970,5 +976,47 @@ mod tests {
             r#"[a    "a"]   [b  "b"  ] 1. a3{"what"}{is}  {this}a2 a3- b2 d4 {cool}   "#,
             "[a \"a\"]\n[b \"b\"]\n\n1. a3 {\"what\"} {is} {this} a2\n2. a3- b2\n3. d4 {cool}\n",
         )]);
+    }
+
+    #[test]
+    fn common_tags() {
+        let ptn_string = r#"
+[Caps "1"]
+[Flats "2"]
+[Clock "15:0 +15"]
+[Date "2022.10.27"]
+[Event "hi"]
+[Komi "2"]
+[Opening "swap"]
+[Player1 "a"]
+[Player2 "b"]
+[Rating1 "123"]
+[Rating2 "1233"]
+[Round "1"]
+[Site "ptn.ninja"]
+[Size "6"]
+[Time "07:49:59"]
+[TPS "x6/1,x2,2,x2/x,2,1,1,x2/x,2,x4/x,1,x,1,x2/x6 2 32"]
+        "#;
+        let ptn: Ptn = ptn_string.parse().unwrap();
+        assert_eq!(ptn.caps(), Some(1));
+        assert_eq!(ptn.flats(), Some(2));
+        assert_eq!(ptn.clock(), Some("15:0 +15"));
+        assert_eq!(ptn.date(), Some(NaiveDate::from_ymd(2022, 10, 27)));
+        assert_eq!(ptn.event(), Some("hi"));
+        assert_eq!(ptn.komi(), Some(2));
+        assert_eq!(ptn.half_komi(), Some(4));
+        assert_eq!(ptn.opening(), Some("swap"));
+        assert_eq!(ptn.player_1(), Some("a"));
+        assert_eq!(ptn.player_2(), Some("b"));
+        assert_eq!(ptn.rating_1(), Some(123));
+        assert_eq!(ptn.rating_2(), Some(1233));
+        assert_eq!(ptn.site(), Some("ptn.ninja"));
+        assert_eq!(ptn.size(), Some(6));
+        assert_eq!(ptn.time(), Some(NaiveTime::from_hms(7, 49, 59)));
+        assert_eq!(
+            ptn.tps(),
+            Tps::from_str("x6/1,x2,2,x2/x,2,1,1,x2/x,2,x4/x,1,x,1,x2/x6 2 32").ok()
+        );
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,0 +1,7 @@
+use crate::{Move, ParseMoveError};
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+    iter::once,
+    str::FromStr,
+};

--- a/src/file.rs
+++ b/src/file.rs
@@ -5,3 +5,140 @@ use std::{
     iter::once,
     str::FromStr,
 };
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Tag {
+    key: String,
+    value: String,
+}
+
+impl Tag {
+    pub fn new<A: Into<String>, B: Into<String>>(key: A, value: B) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+
+    pub fn key(&self) -> &'_ str {
+        &self.key
+    }
+
+    pub fn value(&self) -> &'_ str {
+        &self.value
+    }
+}
+
+impl Display for Tag {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "[{} \"{}\"]", self.key, self.value)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ParseTagError {
+    NoOpeningBracket,
+    MissingKey,
+    NoOpeningQuotationMarks,
+    IllegalEscape,
+    MissingValue,
+    NoClosingQuotationMarks,
+    NoClosingBracket,
+    GarbageAfterValue,
+    GarbageAfterTag,
+}
+
+impl Error for ParseTagError {}
+
+impl Display for ParseTagError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::NoOpeningBracket => "missing opening square bracket '[' at the start",
+            Self::MissingKey => "missing key",
+            Self::NoOpeningQuotationMarks => "missing opening quotation marks '\"' before value",
+            Self::IllegalEscape => "invalid character found after a backslash-escape in the value",
+            Self::MissingValue => "missing value",
+            Self::NoClosingQuotationMarks => "missing closing quotation marks '\"' after value",
+            Self::GarbageAfterValue => "non-whitespace text after closing quotation mark '\"'",
+            Self::NoClosingBracket => "missing closing square bracket ']' at the end",
+            Self::GarbageAfterTag => "text after the closing square bracket ']'",
+        }
+        .fmt(f)
+    }
+}
+
+impl FromStr for Tag {
+    type Err = ParseTagError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut chars = s.chars();
+
+        // open bracket
+        let Some('[') = chars.next() else {Err(ParseTagError::NoOpeningBracket)?};
+
+        // key
+        let mut opened = false;
+        let mut key = String::new();
+        for c in chars.by_ref() {
+            if c == '"' {
+                opened = true;
+                break;
+            }
+            key.push(c);
+        }
+        if !opened {
+            Err(ParseTagError::NoOpeningQuotationMarks)?;
+        }
+        let key = key.trim();
+        if key.is_empty() {
+            Err(ParseTagError::MissingKey)?;
+        }
+
+        // value
+        let mut value = String::new();
+        let mut escape = false;
+        let mut closed = false;
+        for c in chars.by_ref() {
+            if escape {
+                match c {
+                    '"' | '\\' => escape = false,
+                    _ => Err(ParseTagError::IllegalEscape)?,
+                }
+            } else if c == '\\' {
+                escape = true;
+                continue;
+            } else if c == '"' {
+                closed = true;
+                break;
+            }
+
+            value.push(c);
+        }
+        if !closed {
+            Err(ParseTagError::NoClosingQuotationMarks)?;
+        }
+        if value.is_empty() {
+            Err(ParseTagError::MissingValue)?;
+        }
+
+        // closing bracket
+        let mut closed = false;
+        for c in chars.by_ref() {
+            if c == ']' {
+                closed = true;
+                break;
+            }
+            if !c.is_whitespace() {
+                Err(ParseTagError::GarbageAfterValue)?;
+            }
+        }
+        if !closed {
+            Err(ParseTagError::NoClosingBracket)?;
+        }
+        if chars.count() != 0 {
+            Err(ParseTagError::GarbageAfterTag)?
+        }
+
+        Ok(Self::new(key, value))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 #[cfg(test)]
 mod test_utils;
 
+mod file;
 mod ptn;
 mod tps;
 
+pub use file::*;
 pub use ptn::*;
 pub use tps::*;
 
@@ -14,8 +16,6 @@ use std::{
 };
 
 // TODO: serde, docs, tests
-
-// TODO: full ptn strings
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Piece {


### PR DESCRIPTION
Added new public types:
- `Tag` to represent PTN tags
- `ParseTagError`
- `WinReason`
- `GameResult` for the result of tak games
- `ParseGameResultError`
- `Ptn` for the ptn file
- `ParsePtnError`

Kept the "style" of writing everything in one giant file.
Docs are yet to be added, but maybe as a separate pull request.